### PR TITLE
Fixed issue where `-` symbol would break property highlighting

### DIFF
--- a/syntaxes/apache-dispatcher-config.tmLanguage.json
+++ b/syntaxes/apache-dispatcher-config.tmLanguage.json
@@ -28,11 +28,11 @@
 			"patterns": [
 				{
 					"name": "invalid.property.apache-dispatcher-config",
-					"match": "(?<!['\"])(\/{2,}[a-zA-Z0-9_]+)(?!['\"])"
+					"match": "(?<!['\"])(\/{2,}[a-zA-Z0-9_-]+)(?!['\"])"
 				},
 				{
 					"name": "storage.type.property.apache-dispatcher-config",
-					"match": "(?<!['\"])(\/[a-zA-Z0-9_]+)(?!['\"])"
+					"match": "(?<!['\"])(\/[a-zA-Z0-9_-]+)(?!['\"])"
 				}
 			]
 		},


### PR DESCRIPTION
This pull request fixes an issue where properties like `/example-property` do not get highlighted because of the hyphen symbol.